### PR TITLE
Fix quote styling for multiline messages

### DIFF
--- a/src/helpers/sendMfaMessage.ts
+++ b/src/helpers/sendMfaMessage.ts
@@ -29,7 +29,7 @@ export default function sendMfaMessage(
 				type: 'section',
 				text: {
 					type: 'mrkdwn',
-					text: quote(message), // The `>` will make the message quoted
+					text: quote(message),
 				},
 			},
 			{

--- a/src/helpers/sendMfaMessage.ts
+++ b/src/helpers/sendMfaMessage.ts
@@ -29,7 +29,7 @@ export default function sendMfaMessage(
 				type: 'section',
 				text: {
 					type: 'mrkdwn',
-					text: `> ${message}`, // The `>` will make the message quoted
+					text: quote(message), // The `>` will make the message quoted
 				},
 			},
 			{
@@ -79,4 +79,9 @@ function generateMeta(
 			text: `*${title}:* ${value}`,
 		};
 	}
+}
+
+const QUOTE_PREFIX = "> ";
+function quote(text: string) {
+	return QUOTE_PREFIX + text.split("\n").join(`\n${QUOTE_PREFIX}`);
 }


### PR DESCRIPTION
Incoming SMS messages with line breaks resulted in a break in the quote styling.

<img width="446" alt="image" src="https://github.com/hackclub/mfa/assets/20099646/7feee2ce-53cd-45e0-bf4a-4e66f8c0ac28">

This fixes that:

<img width="447" alt="image" src="https://github.com/hackclub/mfa/assets/20099646/4dd22258-eea5-463f-83b0-74dfd393ea45">
