### PR TITLE
Simplify Slack message

### DIFF
--- a/src/helpers/sendMfaMessage.ts
+++ b/src/helpers/sendMfaMessage.ts
@@ -33,34 +33,41 @@ export default function sendMfaMessage(
 				},
 			},
 			{
-				type: 'section',
-				fields: [
-					{
-						type: 'mrkdwn',
-						text: `*From:*\n${from}`,
-					},
-					{
-						type: 'mrkdwn',
-						text: `*To:*\n${to}`,
-					},
-				],
-			},
-			{
 				type: 'context',
-				elements: generateMeta(messageSid, country, state, city, zip),
+				elements: generateMeta({
+					messageSid,
+					from,
+					to,
+					country,
+					state,
+					city,
+					zip,
+				}),
 			},
 		].filter((block) => block), // remove the possible 'undefined' block
 	});
 }
 
-function generateMeta(
-	messageSid: string,
-	country?: string,
-	state?: string,
-	city?: string,
-	zip?: string
-) {
+function generateMeta({
+	messageSid,
+	to,
+	from,
+	country,
+	state,
+	city,
+	zip,
+}: {
+	messageSid: string;
+	from: string;
+	to: string;
+	country?: string;
+	state?: string;
+	city?: string;
+	zip?: string;
+}) {
 	const meta = [
+		singleMeta('From', from),
+		singleMeta('To', to),
 		singleMeta('Country', country),
 		singleMeta('State', state),
 		singleMeta('City', city),
@@ -81,7 +88,7 @@ function generateMeta(
 	}
 }
 
-const QUOTE_PREFIX = "> ";
+const QUOTE_PREFIX = '> ';
 function quote(text: string) {
-	return QUOTE_PREFIX + text.split("\n").join(`\n${QUOTE_PREFIX}`);
+	return QUOTE_PREFIX + text.split('\n').join(`\n${QUOTE_PREFIX}`);
 }

--- a/src/helpers/sendMfaMessage.ts
+++ b/src/helpers/sendMfaMessage.ts
@@ -72,7 +72,7 @@ function generateMeta({
 		singleMeta('State', state),
 		singleMeta('City', city),
 		singleMeta('Zip', zip),
-		singleMeta('MessageSid', messageSid),
+		singleMeta('Twilio MessageSid', messageSid),
 	];
 
 	return meta.filter((v) => v !== null); // Return non-null values

--- a/src/helpers/sendMfaMessage.ts
+++ b/src/helpers/sendMfaMessage.ts
@@ -14,7 +14,7 @@ export default function sendMfaMessage(
 ) {
 	slack.client.chat.postMessage({
 		channel,
-		text: `[${code}]: ${message}`,
+		text: `[${code}] ${message}`,
 		blocks: [
 			code !== null
 				? {


### PR DESCRIPTION
## Before
<img width="434" alt="image" src="https://github.com/hackclub/mfa/assets/20099646/282436e3-9b90-4457-8943-382d1ff0e07e">

<img width="354" alt="image" src="https://github.com/hackclub/mfa/assets/20099646/7db4ffa9-1eca-434a-9150-96f297f00d5a">

- The `To` and `From` fields unnecessarily draw attention
- The text version (that's used in notification previews) contains two colons; one added by Slack and another within our own copy.

## After

<img width="449" alt="image" src="https://github.com/hackclub/mfa/assets/20099646/6847ba6e-a9d0-4aec-a17c-bd3a328f89b5">

<img width="350" alt="image" src="https://github.com/hackclub/mfa/assets/20099646/3b1439bc-0e08-4718-839f-66e1a727ed77">

- The `To` and `From` fields have been moved to the context footer. Technically, the `To` field isn't needed since we only have one phone number. However, I thought I'd just keep it fo now.
- The second colon in the text version has been removed!
- `MessageSid` has been renamed to `Twilio MessageSid` to provide more clarity